### PR TITLE
[Major][Performance] Update diffId from String to Int.

### DIFF
--- a/Sources/SwiftUIKit/ListDiffable.swift
+++ b/Sources/SwiftUIKit/ListDiffable.swift
@@ -15,17 +15,25 @@ import CZUtils
  `ForEach(feeds, id: \.diffId)`.
  */
 public protocol ListDiffable {
+  /// Type of the diffId. Defaults to Int.
+  typealias ID = Int
+  
   /// Diffable id be used for List identifierable.
-  var diffId: String { get }
+  var diffId: ID { get }
 }
 
 /**
  Convenient implementation of ListDiffable if Self conforms Identifiable protocol.
  */
 public extension ListDiffable where Self: Identifiable {
-  var diffId: String {
-    assert(self.id is CustomStringConvertible, "self.id should conform CustomStringConvertible protocol.")
-    return String(describing:self.id)
+  var diffId: ListDiffable.ID {
+    // dbgPrint("ListDiffable.diffId = \(self.id)")
+    
+    if let intId = self.id as? Int {
+      return intId
+    }
+    assertionFailure("`self.id` should be Int to improve performance - all `diffId`s are called for each cell update. O(N^2)")
+    return self.id.hashValue
   }
 }
 

--- a/Sources/SwiftUIKit/ListDiffable.swift
+++ b/Sources/SwiftUIKit/ListDiffable.swift
@@ -15,7 +15,7 @@ import CZUtils
  `ForEach(feeds, id: \.diffId)`.
  */
 public protocol ListDiffable {
-  /// Type of the diffId. Defaults to Int.
+  /// Type of diffId. Defaults to Int.
   typealias ID = Int
   
   /// Diffable id be used for List identifierable.
@@ -29,13 +29,11 @@ public protocol ListDiffable {
  */
 public extension ListDiffable where Self: Identifiable {
   var diffId: ListDiffable.ID {
-    // dbgPrint("ListDiffable.diffId = \(self.id)")
-    
-    if let intId = self.id as? Int {
+    if let intId = id as? Int {
       return intId
     }
     assertionFailure("`self.id` should be Int to improve performance - all `diffId`s are called for each cell update. O(N^2)")
-    return self.id.hashValue
+    return id.hashValue
   }
 }
 

--- a/Sources/SwiftUIKit/ListDiffable.swift
+++ b/Sources/SwiftUIKit/ListDiffable.swift
@@ -19,6 +19,8 @@ public protocol ListDiffable {
   typealias ID = Int
   
   /// Diffable id be used for List identifierable.
+  ///
+  /// - Note: All diffIds are called for each Cell update. time = N^2 (N = cellCount).
   var diffId: ID { get }
 }
 


### PR DESCRIPTION
### Description

- Stuck when loadMore - 20 pages (*Memory warning: 600M - not released) (Simulator)

## Reasons

- **diffId: 8.5% CPU** (ListDiffable<>.diffId.getter)
  - **All diffIds: are called for each Cell update O(N^2)**

## Solution

- Update `ListDiffable.diffId` from String(descibing:) to Int. 
  - `ListDiffable.diffId` time: 8.5% -> 0.8%

Ticket: https://github.com/geekaurora/CZGithubReactAppKit/issues/5